### PR TITLE
Utility for swapping Raylib.Vector2 to Jaylib.Vector2 and vice versa

### DIFF
--- a/src/com/raylib/Jaylib.java
+++ b/src/com/raylib/Jaylib.java
@@ -39,6 +39,7 @@ public class Jaylib extends Raylib{
     public static Raylib.Vector2 jVector2ToRVector2(Jaylib.Vector2 vect) {
         return new Raylib.Vector2().x(vect.x()).y(vect.y());
     }
+
     public static class Color extends Raylib.Color{
         public Color(int r, int g, int b, int a){
             super();

--- a/src/com/raylib/Jaylib.java
+++ b/src/com/raylib/Jaylib.java
@@ -62,9 +62,9 @@ public class Jaylib extends Raylib{
     }
 
     public static class Camera2D extends Raylib.Camera2D{
-        public Camera2D(Raylib.Vector2 position, Raylib.Vector2 target, float rotation, float zoom) {
+        public Camera2D(Raylib.Vector2 offset, Raylib.Vector2 target, float rotation, float zoom) {
             super();
-            _position(position);
+            offset(offset);
             target(target);
             rotation(rotation);
             zoom(zoom);

--- a/src/com/raylib/Jaylib.java
+++ b/src/com/raylib/Jaylib.java
@@ -32,6 +32,13 @@ public class Jaylib extends Raylib{
         return new Raylib.Color().r((byte) r).g((byte) g).b((byte) b).a((byte) a);
     }
 
+    public static Jaylib.Vector2 rVector2ToJVector2(Raylib.Vector2 vect) {
+        return new Jaylib.Vector2(vect.x, vect.y);
+    }
+
+    public static Raylib.Vector2 jVector2ToRVector2(Jaylib.Vector2 vect) {
+        return new Raylib.Vector2().x(vect.x()).y(vect.y());
+    }
     public static class Color extends Raylib.Color{
         public Color(int r, int g, int b, int a){
             super();

--- a/src/com/raylib/Jaylib.java
+++ b/src/com/raylib/Jaylib.java
@@ -33,7 +33,7 @@ public class Jaylib extends Raylib{
     }
 
     public static Jaylib.Vector2 rVector2ToJVector2(Raylib.Vector2 vect) {
-        return new Jaylib.Vector2(vect.x, vect.y);
+        return new Jaylib.Vector2(vect.x(), vect.y());
     }
 
     public static Raylib.Vector2 jVector2ToRVector2(Jaylib.Vector2 vect) {

--- a/src/com/raylib/Jaylib.java
+++ b/src/com/raylib/Jaylib.java
@@ -53,6 +53,16 @@ public class Jaylib extends Raylib{
         }
     }
 
+    public static class Camera2D extends Raylib.Camera2D{
+        public Camera2D(Raylib.Vector2 position, Raylib.Vector2 target, float rotation, float zoom) {
+            super();
+            _position(position);
+            target(target);
+            rotation(rotation);
+            zoom(zoom);
+        }
+    }
+
     public Raylib.Rectangle Rectangle(float x, float y, float width, float height) {
         return new Raylib.Rectangle().x(x).y(y).width(width).height(height);
     }


### PR DESCRIPTION
Added a simple utility to do what the title says. May be unnessesary but may cause compilation issues is different vectors are used across projects. 